### PR TITLE
Auth postgres split

### DIFF
--- a/auth/dockerfile
+++ b/auth/dockerfile
@@ -1,6 +1,5 @@
 FROM node:alpine
 
-ENV host=""
 WORKDIR /app 
 COPY package.json .
 RUN npm install 

--- a/auth/src/app.ts
+++ b/auth/src/app.ts
@@ -18,7 +18,7 @@ app.use(
 app.use(signupRouter);
 
 app.get("/", (req: Request, res: Response) => {
-  res.send("Root routes");
+  res.send("Root routes fun - er - er er");
 });
 
 export { app };

--- a/auth/src/app.ts
+++ b/auth/src/app.ts
@@ -4,21 +4,29 @@ import cookieSession from "cookie-session";
 
 const app = express();
 
-// TODO: Security additions
+//Security TODOS:
+//     - Same site
+//     - Double submit CSRF tokens for stateless CSRF protection
 app.use(express.json());
 app.use(
   cookieSession({
     maxAge: 1000 * 60 * 60, // an hour long session
     secure: false, // TODO: Secure when running in Prod
-    httpOnly: true, // Security measure to help prevent XSS
+    httpOnly: true, // Security measure to help prevent XSS attempts to steal a user's session
     keys: ["username", "email"],
+    // sameSite: true,
+    //  To do this, I need to add the Host statement in
+    //  the Ingress yaml[ i believ host value should mathc the
+    //  ingress-nginx-controller Service's External IP or can be a
+    //  different value if in the host file I convert a different
+    //  domain name (like microstore.dev) to localhost]
   })
 );
 
 app.use(signupRouter);
 
 app.get("/", (req: Request, res: Response) => {
-  res.send("Root routes fun - er - er er");
+  res.send("Root routes fun");
 });
 
 export { app };

--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -1,33 +1,46 @@
 import { app } from "./app";
 import { Pool } from "./pool";
 
+// TODO: Change default PG_USER env variable
+// TODO: FIx two problems:
+//       1. Connect to an auth-micro database that may not always exist
+//       2. Run the migrations if there is no table
 (async () => {
-  if (!process.env.HOST) {
+  if (!process.env.PG_HOST) {
     throw new Error("No host detected");
   }
 
-  if (!process.env.DATABASE) {
+  if (!process.env.PG_DATABASE) {
     throw new Error("No database detected");
   }
 
-  if (!process.env.PASSWORD) {
+  if (!process.env.PG_PASSWORD) {
     throw new Error("No password detected");
   }
 
-  const PORT = process.env.port || 3000;
+  if (!process.env.PG_PORT) {
+    throw new Error("No port detected");
+  }
+
+  if (!process.env.JWT_KEY) {
+    throw new Error("No jwt secret key defined");
+  }
+
+  let PG_PORT = process.env.PG_PORT;
 
   // connect to postgres using the pool singleton
   const connectionResult = await Pool.connect({
-    host: process.env.HOST,
-    port: 5432,
-    database: process.env.DATABASE,
-    password: process.env.PASSWORD,
+    host: process.env.PG_HOST,
+    port: parseInt(PG_PORT),
+    database: "postgres",
+    password: process.env.PG_PASSWORD,
+    user: process.env.PG_USER,
   });
 
   // check if the connection was successful
   if (connectionResult.rows) {
-    app.listen(PORT, () => {
-      console.log(`Listening on port ${PORT}`);
+    app.listen(3000, () => {
+      console.log(`Listening on port 3000`);
     });
   } else {
     throw new Error("Bad connection");

--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -69,7 +69,7 @@ import migrate from "node-pg-migrate";
       });
     }
     app.listen(3000, () => {
-      console.log(`Listening on port 3000`);
+      console.log(`Listening on port 3006`);
     });
   } else {
     throw new Error("Bad connection");

--- a/auth/src/pool.ts
+++ b/auth/src/pool.ts
@@ -1,8 +1,5 @@
 import { Pool, PoolConfig } from "pg";
 
-// IMP: https://github.com/brianc/node-postgres/tree/master/packages/pg-pool
-//      Need to pass information for a non-local postgres instance in through a config object
-//      So when postgres is running in a separate container this will need modificaiton
 export class PoolSingleton {
   private _pool: Pool | undefined = undefined;
   connect(config: PoolConfig) {

--- a/auth/src/routes/signup.ts
+++ b/auth/src/routes/signup.ts
@@ -49,7 +49,7 @@ router.post(
         jwt: createJWT(user.username, user.email),
       };
 
-      // send back a 201
+      // send back a 201 k
       return res.status(201).send(user);
     } catch (e) {
       console.error(e);

--- a/infra/k8s/auth-cluster-ip-service.yaml
+++ b/infra/k8s/auth-cluster-ip-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-cluster-ip-service
+spec:
+  selector:
+    app: auth-micro
+  ports:
+    - name: auth-micro
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/infra/k8s/auth-micro-depl.yaml
+++ b/infra/k8s/auth-micro-depl.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-micro-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: auth-micro
+  template:
+    metadata:
+      labels:
+        app: auth-micro
+    spec:
+      containers:
+        - name: auth-micro
+          image: aaronpazm/auth-micro
+          env:
+            - name: PG_HOST
+              value: auth-postgres-cluster-ip-service
+            - name: PG_PORT
+              value: "5432"
+            - name: PG_DATABASE
+              value: auth
+            - name: PG_USER
+              value: postgres
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pgpassword
+                  key: PG_PASSWORD
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jwtkey
+                  key: JWT_KEY

--- a/infra/k8s/auth-postgres-cluster-ip-service.yaml
+++ b/infra/k8s/auth-postgres-cluster-ip-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-postgres-cluster-ip-service
+spec:
+  type: ClusterIP
+  selector:
+    component: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/infra/k8s/auth-postgres-depl.yaml
+++ b/infra/k8s/auth-postgres-depl.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: postgres
+  template:
+    metadata:
+      labels:
+        component: postgres
+    spec:
+      volumes: # declare what volumes are available for this deployment
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: auth-postgres-persistent-volume-claim
+      containers:
+        - name: postgres
+          image: postgres
+          env: # tell postgres what password to use instead of its default value when starting the container
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pgpassword
+                  key: PG_PASSWORD
+          ports:
+            - containerPort: 5432
+          volumeMounts: # tell kubernetes to actually use one or more of the available volumes
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data #tell kubernetes where we want the volume to persist data -- in this case where postgres stores its data
+              subPath: postgres # allows postgres to open and store data in a mounted volume -- by default this isn't allowed

--- a/infra/k8s/auth-postgres-persistent-volume-claim.yaml
+++ b/infra/k8s/auth-postgres-persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: auth-postgres-persistent-volume-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/infra/k8s/ingress-service.yaml
+++ b/infra/k8s/ingress-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-service
+  annotations: # additional config options
+    kubernetes.io/ingress.class: nginx # tell kubernetes we want an ingress controller based on nginx-ingress project
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-cluster-ip-service
+                port:
+                  number: 3000

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,19 @@
+apiVersion: skaffold/v2beta12
+kind: Config
+deploy:
+  kubectl:
+    manifests:
+      - infra/k8s/auth-micro-depl.yaml
+      - infra/k8s/auth-cluster-ip-service.yaml
+build:
+  local:
+    push: false
+  artifacts:
+    - image: aaronpazm/auth-micro
+      context: auth # the folder that holds our app we make an image form
+      docker:
+        dockerfile: Dockerfile
+      sync: # IMP: Don't add databases or PVCs to Skaffold because they will automatically be shut down when you exit dev mode. This loses the data
+        manual:
+          - src: "src/**/*.ts"
+            dest: .


### PR DESCRIPTION
While running in a Kubernetes cluster the postgres database for the authentication service 
now runs in a separate deployment. The auth service can now connect to Postgres based off the environment variables setup in the kubernetes infrastructure files for the auth service and its corresponding postgres deployment infrastructure yamls. 
When running outside of a kubernetes cluster the service works by connecting to a postgres
installation running on the host machine using environment variables in a .env file. 